### PR TITLE
feat: Zipf board generation

### DIFF
--- a/src/bammi.ts
+++ b/src/bammi.ts
@@ -17,7 +17,7 @@
  */
 export type PlayerIndex = number
 
-class Position {
+export class Position {
     public column: number
     public row: number
 

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -1,4 +1,5 @@
 import { Position } from "../math/position"
+import { generate_checkerboard_board } from "./board_generation"
 
 /**
  * The game of Bammi:
@@ -37,22 +38,15 @@ export class BammiBoardState {
         this.BOARD_WIDTH = board_width
         this.BOARD_HEIGHT = board_height
 
-        // Some arbitrary board
-        // One area per column, for now
-        for (let column = 0; column < this.BOARD_WIDTH; column++) {
-            
-            for (let row = 0; row < this.BOARD_HEIGHT; row++) {
-                const cells: Position[] = []
-                cells.push(new Position(column, row))
-                this.areas.push({
-                    owning_player: 0,
-                    cells: cells,
-                    pie_size: 0,
-                    slice_count: 0
-                })
+        const cell_groups = generate_checkerboard_board(this.BOARD_WIDTH, this.BOARD_HEIGHT)
+        this.areas = cell_groups.map((group) => {
+            return {
+                owning_player: 0,
+                cells: group,
+                pie_size: 0,
+                slice_count: 0
             }
-
-        }
+        })
 
         // Initialize pie sizes
         for (let index = 0; index < this.areas.length; index++) {

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -1,3 +1,5 @@
+import { Position } from "../math/position"
+
 /**
  * The game of Bammi:
  * - The board is a grid of cells, distributed in areas.
@@ -16,29 +18,6 @@
  * An index of 0 means no player
  */
 export type PlayerIndex = number
-
-export class Position {
-    public column: number
-    public row: number
-
-    constructor(column: number, row: number) {
-        this.column = column
-        this.row = row
-    }
-
-    public equals(other: Position): boolean {
-        return this.column === other.column && this.row === other.row
-    }
-
-    /**
-     * Returns false if the positions are equal
-     */
-    public is_adjacent(other: Position): boolean {
-        if (this.equals(other)) return false
-        return Math.abs(this.column - other.column) === 1
-            || Math.abs(this.row - other.row) === 1
-    }
-}
 
 type Area = {
     owning_player: PlayerIndex,
@@ -61,18 +40,18 @@ export class BammiBoardState {
         // Some arbitrary board
         // One area per column, for now
         for (let column = 0; column < this.BOARD_WIDTH; column++) {
-            const cells: Position[] = []
-
+            
             for (let row = 0; row < this.BOARD_HEIGHT; row++) {
+                const cells: Position[] = []
                 cells.push(new Position(column, row))
+                this.areas.push({
+                    owning_player: 0,
+                    cells: cells,
+                    pie_size: 0,
+                    slice_count: 0
+                })
             }
 
-            this.areas.push({
-                owning_player: 0,
-                cells: cells,
-                pie_size: 0,
-                slice_count: 0
-            })
         }
 
         // Initialize pie sizes

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -1,5 +1,5 @@
 import { get_area_adjacent_positions, Position } from "../math/position"
-import { generate_checkerboard_board } from "./board_generation"
+import { generate_checkerboard_board, generate_zipf_board } from "./board_generation"
 
 /**
  * The game of Bammi:
@@ -38,7 +38,7 @@ export class BammiBoardState {
         this.BOARD_WIDTH = board_width
         this.BOARD_HEIGHT = board_height
 
-        const cell_groups = generate_checkerboard_board(this.BOARD_WIDTH, this.BOARD_HEIGHT)
+        const cell_groups = generate_zipf_board(this.BOARD_WIDTH, this.BOARD_HEIGHT)
         this.areas = cell_groups.map((group) => {
             return {
                 owning_player: 0,

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -1,5 +1,5 @@
 import { get_area_adjacent_positions, Position } from "../math/position"
-import { generate_checkerboard_board, generate_zipf_board } from "./board_generation"
+import { generate_zipf_board } from "./board_generation"
 
 /**
  * The game of Bammi:
@@ -113,7 +113,7 @@ export class BammiGame {
     constructor() {
         this._turn_order = [ 1, 2 ]
         this._turn_index = 0
-        this.board_state = new BammiBoardState(5, 5)
+        this.board_state = new BammiBoardState(8, 8)
     }
 
     public get_active_player(): PlayerIndex {

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -1,4 +1,4 @@
-import { Position } from "../math/position"
+import { get_area_adjacent_positions, Position } from "../math/position"
 import { generate_checkerboard_board } from "./board_generation"
 
 /**
@@ -71,24 +71,10 @@ export class BammiBoardState {
     public get_adjacent_areas(area: Area): Area[] {
         const adjacent_area_set: Set<Area> = new Set()
 
-        const cells = area.cells
-            .flatMap((area_cell) =>
-                [ // Gather adjacent cells from area
-                    new Position(area_cell.column + 1, area_cell.row),
-                    new Position(area_cell.column - 1, area_cell.row),
-                    new Position(area_cell.column, area_cell.row + 1),
-                    new Position(area_cell.column, area_cell.row - 1)
-                ])
-            .filter((cell) => !area.cells.some((area_cell) => area_cell.equals(cell))) // Remove cells that are in the original area
-            .reduce<Position[]>((acc, val) => {
-                if (!acc.some((pos) => pos.equals(val))) {
-                    acc.push(val)
-                }
-                return acc
-            }, [])
+        const positions = get_area_adjacent_positions(area.cells)
 
-        cells.forEach((cell) => {
-            const found_area = this.get_area(cell.column, cell.row)
+        positions.forEach((position) => {
+            const found_area = this.get_area(position.column, position.row)
             if (found_area) {
                 adjacent_area_set.add(found_area)
             }

--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -113,7 +113,7 @@ export class BammiGame {
     constructor() {
         this._turn_order = [ 1, 2 ]
         this._turn_index = 0
-        this.board_state = new BammiBoardState(10, 10)
+        this.board_state = new BammiBoardState(5, 5)
     }
 
     public get_active_player(): PlayerIndex {

--- a/src/game/board_generation.ts
+++ b/src/game/board_generation.ts
@@ -1,8 +1,8 @@
-import { Position } from "../math/position";
+import { Position } from "../math/position"
 
-export function generate_checkerboard_board(width: number, height: number): Position[][]{
+export function generate_checkerboard_board(width: number, height: number): Position[][] {
     const result: Position[][] = []
-    
+
     for (let column = 0; column < width; column++) {
         for (let row = 0; row < height; row++) {
             const cells: Position[] = []
@@ -11,8 +11,46 @@ export function generate_checkerboard_board(width: number, height: number): Posi
         }
     }
     return result
-} 
+}
 
 export function generate_zipf_board(width: number, height: number): Position[][] {
-    return []
+    const cell_groups: Position[][] = []
+    let cell_set: Position[] = []
+
+    for (let column = 0; column < width; column++) {
+        for (let row = 0; row < height; row++) {
+            cell_set.push(new Position(column, row))
+        }
+    }
+
+    function finished(): boolean {
+        return cell_set.length === 0
+    }
+
+    function get_random_point(): Position {
+        return new Position(
+            Math.floor(Math.random() * width),
+            Math.floor(Math.random() * height)
+        )
+    }
+
+    let failsafe = 1000
+
+    do {
+        failsafe--
+        const random_point = get_random_point()
+
+        const existing_group = cell_groups.find((group) => group.some((cell) => cell.equals(random_point)))
+
+        if (existing_group) {
+            // Add random in-bounds unoccupied adjacent cell
+        }
+        else {
+            // Remove cell from tracking set
+            cell_set = cell_set.filter((cell) => !cell.equals(random_point))
+            cell_groups.push([ random_point ])
+        }
+    } while (!finished() && failsafe > 0)
+
+    return cell_groups
 }

--- a/src/game/board_generation.ts
+++ b/src/game/board_generation.ts
@@ -1,4 +1,4 @@
-import { Position } from "../math/position"
+import { get_area_adjacent_positions, Position } from "../math/position"
 
 export function generate_checkerboard_board(width: number, height: number): Position[][] {
     const result: Position[][] = []
@@ -44,6 +44,21 @@ export function generate_zipf_board(width: number, height: number): Position[][]
 
         if (existing_group) {
             // Add random in-bounds unoccupied adjacent cell
+            const adjacent_cells = get_area_adjacent_positions(existing_group)
+                .filter((cell) => cell.column >= 0 && cell.column < width && cell.row >= 0 && cell.row < height)
+                .filter((cell) => {
+                    return cell_groups.some((group) => {
+                        // Only cells that aren't contained in a group
+                        return group.some((group_cell) => group_cell.equals(cell))
+                    }) === false
+                })
+
+            if (adjacent_cells.length > 0) {
+                const random_adjacent_cell = adjacent_cells[Math.floor(Math.random() * adjacent_cells.length)]
+                // Remove cell from tracking set
+                cell_set = cell_set.filter((cell) => !cell.equals(random_adjacent_cell))
+                existing_group.push(random_adjacent_cell)
+            }
         }
         else {
             // Remove cell from tracking set

--- a/src/game/board_generation.ts
+++ b/src/game/board_generation.ts
@@ -1,0 +1,18 @@
+import { Position } from "../math/position";
+
+export function generate_checkerboard_board(width: number, height: number): Position[][]{
+    const result: Position[][] = []
+    
+    for (let column = 0; column < width; column++) {
+        for (let row = 0; row < height; row++) {
+            const cells: Position[] = []
+            cells.push(new Position(column, row))
+            result.push(cells)
+        }
+    }
+    return result
+} 
+
+export function generate_zipf_board(width: number, height: number): Position[][] {
+    return []
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { BammiGame, Position } from "./bammi"
+import { BammiGame } from "./game/bammi"
+import { Position } from "./math/position";
 
 function main(): void {
     const web_socket = new WebSocket("ws://localhost:3000", "bammi");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BammiGame } from "./bammi"
+import { BammiGame, Position } from "./bammi"
 
 function main(): void {
     const web_socket = new WebSocket("ws://localhost:3000", "bammi");
@@ -30,22 +30,41 @@ function main(): void {
 
         const state = bammi_game.board_state
 
-        for (let index = 0; index < state.areas.length; index++) {
-            const element = state.areas[index]
+        for (let area_index = 0; area_index < state.areas.length; area_index++) {
+            const area = state.areas[area_index]
 
-            element.cells.forEach((cell) => {
+            area.cells.forEach((cell, cell_index) => {
                 const cell_element = grid.appendChild(document.createElement('div'))
                 cells.push(cell_element)
                 cell_element.classList.add('game-cell')
-                cell_element.classList.add('player-' + element.owning_player.toFixed(0))
+                cell_element.classList.add('player-' + area.owning_player.toFixed(0))
                 cell_element.style.gridColumn = (cell.column + 1).toFixed(0)
                 cell_element.style.gridRow = (cell.row + 1).toFixed(0)
 
-                cell_element.textContent = `${element.slice_count}/${element.pie_size}`
+                if (cell_index === 0) {
+                    cell_element.textContent = `${area.slice_count}/${area.pie_size}`
+                }
 
                 cell_element.onclick = (): void => {
                     bammi_game.submit_move(cell.column, cell.row, bammi_game.get_active_player())
                     update_board()
+                }
+                const top_adjacent = new Position(cell.column, cell.row - 1)
+                const bottom_adjacent = new Position(cell.column, cell.row + 1)
+                const left_adjacent = new Position(cell.column - 1, cell.row)
+                const right_adjacent = new Position(cell.column + 1, cell.row)
+
+                if (state.get_area(top_adjacent.column, top_adjacent.row) !== area) {
+                    cell_element.style.borderTopColor = 'black'
+                }
+                if (state.get_area(bottom_adjacent.column, bottom_adjacent.row) !== area) {
+                    cell_element.style.borderBottomColor = 'black'
+                }
+                if (state.get_area(left_adjacent.column, left_adjacent.row) !== area) {
+                    cell_element.style.borderLeftColor = 'black'
+                }
+                if (state.get_area(right_adjacent.column, right_adjacent.row) !== area) {
+                    cell_element.style.borderRightColor = 'black'
                 }
             })
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { BammiGame } from "./game/bammi"
-import { Position } from "./math/position";
+import { Position } from "./math/position"
 
 function main(): void {
-    const web_socket = new WebSocket("ws://localhost:3000", "bammi");
+    const web_socket = new WebSocket("ws://localhost:3000", "bammi")
 
     web_socket.onopen = (event: Event): void => {
         const msg = {
@@ -37,13 +37,17 @@ function main(): void {
             area.cells.forEach((cell, cell_index) => {
                 const cell_element = grid.appendChild(document.createElement('div'))
                 cells.push(cell_element)
-                cell_element.classList.add('game-cell')
-                cell_element.classList.add('player-' + area.owning_player.toFixed(0))
+                const player_class = 'player-' + area.owning_player.toFixed(0)
+                cell_element.classList.add('game-cell', 'medium', player_class)
                 cell_element.style.gridColumn = (cell.column + 1).toFixed(0)
                 cell_element.style.gridRow = (cell.row + 1).toFixed(0)
 
                 if (cell_index === 0) {
-                    cell_element.textContent = `${area.slice_count}/${area.pie_size}`
+                    const pie = cell_element.appendChild(document.createElement('div'))
+                    pie.classList.add('pie', player_class)
+                    const fill_percentage = ((area.slice_count / area.pie_size) * 100).toPrecision(2)
+                    const color_var = 'var(--pie-color)'
+                    pie.style.backgroundImage = `conic-gradient(${color_var} 0%, ${color_var} ${fill_percentage}%, transparent ${fill_percentage}%)`
                 }
 
                 cell_element.onclick = (): void => {

--- a/src/math/position.ts
+++ b/src/math/position.ts
@@ -1,0 +1,22 @@
+export class Position {
+    public column: number
+    public row: number
+
+    constructor(column: number, row: number) {
+        this.column = column
+        this.row = row
+    }
+
+    public equals(other: Position): boolean {
+        return this.column === other.column && this.row === other.row
+    }
+
+    /**
+     * Returns false if the positions are equal
+     */
+    public is_adjacent(other: Position): boolean {
+        if (this.equals(other)) return false
+        return Math.abs(this.column - other.column) === 1
+            || Math.abs(this.row - other.row) === 1
+    }
+}

--- a/src/math/position.ts
+++ b/src/math/position.ts
@@ -20,3 +20,28 @@ export class Position {
             || Math.abs(this.row - other.row) === 1
     }
 }
+
+export function get_adjacent_positions(position: Position): Position[] {
+    return [ // Gather adjacent cells from area
+        new Position(position.column + 1, position.row),
+        new Position(position.column - 1, position.row),
+        new Position(position.column, position.row + 1),
+        new Position(position.column, position.row - 1)
+    ]
+}
+
+/**
+ * A set of all positions that are orthogonally adjacent to any position in the input set, excluding cells in the input set
+ */
+export function get_area_adjacent_positions(in_positions: Position[]): Position[] {
+    return in_positions
+        .flatMap((in_position) => get_adjacent_positions(in_position)) // Get adjacent cells to all input cells
+        .filter((position) => !in_positions.some((in_position) => in_position.equals(position))) // Remove cells that are in the original array
+        .reduce<Position[]>((out_list, position) => {
+            // Loop through list of positions, only adding to output list if not already in it
+            if (!out_list.some((pos) => pos.equals(position))) {
+                out_list.push(position)
+            }
+            return out_list
+        }, [])
+}

--- a/src/style.css
+++ b/src/style.css
@@ -12,8 +12,8 @@ body {
 .game-cell {
     --cell-color: white;
     background-color: var(--cell-color);
-    width: 32px;
-    height: 32px;
+    width: 128px;
+    height: 128px;
     border-width: 1px;
     border-color: transparent;
     border-style: solid;

--- a/src/style.css
+++ b/src/style.css
@@ -1,24 +1,28 @@
 body {
-    background-color: aqua;
+    background-color: palegoldenrod;
 }
 
 #game-grid {
-    background-color: white;
+    background-color: gray;
     display: grid;
     justify-content: center;
     align-items: center;
 }
 
 .game-cell {
-    background-color: gray;
+    --cell-color: white;
+    background-color: var(--cell-color);
     width: 32px;
     height: 32px;
+    border-width: 1px;
+    border-color: transparent;
+    border-style: solid;
 }
 
 .game-cell.player-1 {
-    background-color: blue;
+    --cell-color: lightblue;
 }
 
 .game-cell.player-2 {
-    background-color: red;
+    --cell-color: pink;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -10,10 +10,11 @@ body {
 }
 
 .game-cell {
+    --cell-size: 128px;
     --cell-color: white;
     background-color: var(--cell-color);
-    width: 128px;
-    height: 128px;
+    width: var(--cell-size);
+    height: var(--cell-size);
     border-width: 1px;
     border-color: transparent;
     border-style: solid;
@@ -25,4 +26,31 @@ body {
 
 .game-cell.player-2 {
     --cell-color: pink;
+}
+
+.game-cell.small {
+    --cell-size: 32px;
+}
+
+.game-cell.medium {
+    --cell-size: 96px;
+}
+
+.game-cell.large {
+    --cell-size: 128px;
+}
+
+.pie {
+    --pie-color: green;
+    clip-path: circle(35% at center);
+    width: 100%;
+    height: 100%;
+}
+
+.pie.player-1 {
+    --pie-color: blue;
+}
+
+.pie.player-2 {
+    --pie-color: red;
 }


### PR DESCRIPTION
A Zipf-inspired algorithm for generating the initial board state.
Essentially:
- Select a random cell in the grid
- If the cell does not already belong to an area, create a new area with that cell as it's only member
- Otherwise, pick a random cell that borders the area to which the original cell belongs. Outlining cells that are out of bounds or belong to another area are disregarded. If no cells are found, continue
- When all cells belong to an area, return

Also...
A moderate refactoring of file locations
Adding borders to grid cells to demarcate which area they belong to
Adding math "library" with functions for getting adjacent cells of positions, and "outlining" cells of a list of positions
