### PR TITLE
Showcase: TypeScript type guards

### DIFF
--- a/src/game/bammi.ts
+++ b/src/game/bammi.ts
@@ -105,6 +105,47 @@ export class BammiBoardState {
     }
 }
 
+export enum TurnEventType {
+    END = 'END',
+    ADD = 'ADD',
+    EXPLOSION = 'EXPLOSION',
+    VICTORY = 'VICTORY'
+}
+
+
+export class TurnEvent {
+    public is<T extends TurnEventType, K = EventMap[T]>(event_type: T): this is K {
+        return event_type === this.event_type
+    }
+    protected event_type: TurnEventType | undefined
+}
+
+export class AddTurnEvent extends TurnEvent {
+    protected override event_type = TurnEventType.ADD
+    constructor(public area_to_add_to: Area) { super() }
+}
+
+export class VictoryTurnEvent extends TurnEvent {
+    protected override event_type = TurnEventType.VICTORY
+    constructor(public winning_player: PlayerIndex) { super() }
+}
+
+export class ExplosionTurnEvent extends TurnEvent {
+    protected override event_type = TurnEventType.EXPLOSION
+    constructor(public exploding_area: Area, public adjacent_areas: Area[]) { super() }
+}
+
+export class EndTurnEvent extends TurnEvent {
+    protected override event_type = TurnEventType.END
+}
+
+interface EventMap {
+    [TurnEventType.ADD]: AddTurnEvent;
+    [TurnEventType.END]: EndTurnEvent;
+    [TurnEventType.EXPLOSION]: ExplosionTurnEvent;
+    [TurnEventType.VICTORY]: VictoryTurnEvent;
+}
+
 export class BammiGame {
     public board_state: BammiBoardState
     private _turn_order: PlayerIndex[]
@@ -120,25 +161,28 @@ export class BammiGame {
         return this._turn_order[this._turn_index]
     }
 
-    public submit_move(column: number, row: number, player: PlayerIndex): void {
+    public submit_move(column: number, row: number, player: PlayerIndex): TurnEvent[] {
         if (this.board_state.get_win_state() !== undefined) {
             console.log("We already have a winner, you can't play any more")
-            return
+            return []
         }
 
         const area = this.board_state.get_area(column, row)
         if (!area) {
             console.error("Area at column", column, "and row", row, "has no area to be found!")
-            return
+            return []
         }
 
         if (area.owning_player !== 0 && area.owning_player !== player) {
             console.warn("Player", player, "cannot add to area at column", column, "and row", row)
-            return
+            return []
         }
 
         // Increment player pointer
         this._turn_index = (this._turn_index + 1) % this._turn_order.length
+
+        // Initialize turn event array
+        const result: TurnEvent[] = []
 
         let areas_to_add_to = [ area ]
 
@@ -150,18 +194,25 @@ export class BammiGame {
             if (top_area.slice_count >= top_area.pie_size) {
                 // Explosion
                 top_area.slice_count = 0
-                areas_to_add_to.push(...this.board_state.get_adjacent_areas(top_area))
+                const adjacent_areas = this.board_state.get_adjacent_areas(top_area)
+                areas_to_add_to.push(...adjacent_areas)
+                result.push(new ExplosionTurnEvent(top_area, adjacent_areas))
             }
 
             top_area.slice_count++
+            result.push(new AddTurnEvent(top_area))
 
             const winner = this.board_state.get_win_state()
 
             if (winner !== undefined) {
                 console.log("We have a winner! Player with index", winner)
-                return
+                result.push(new VictoryTurnEvent(player))
+                return result
             }
         }
+
+        result.push(new EndTurnEvent())
+        return result
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BammiGame } from "./game/bammi"
+import { BammiGame, TurnEventType } from "./game/bammi"
 import { get_player_info } from "./game/player_info"
 import { Position } from "./math/position"
 
@@ -68,7 +68,21 @@ function main(): void {
                 }
 
                 cell_element.onclick = (): void => {
-                    bammi_game.submit_move(cell.column, cell.row, bammi_game.get_active_player())
+                    const result = bammi_game.submit_move(cell.column, cell.row, bammi_game.get_active_player())
+                    result.forEach((turn_event) => {
+                        if (turn_event.is(TurnEventType.ADD)) {
+                            console.log("Add-event! Adding to", turn_event.area_to_add_to)
+                        }
+                        else if (turn_event.is(TurnEventType.END)) {
+                            console.log("End-event! Turn is now ending", turn_event)
+                        }
+                        else if (turn_event.is(TurnEventType.EXPLOSION)) {
+                            console.log("Boom! Explosion", turn_event)
+                        }
+                        else if (turn_event.is(TurnEventType.VICTORY)) {
+                            console.log("It's game over. The winner is", turn_event.winning_player)
+                        }
+                    })
                     update_board()
                 }
                 const top_adjacent = new Position(cell.column, cell.row - 1)


### PR DESCRIPTION
Type guarded turn events

Time for a TypeScript lesson!

Base class `TurnEvent` has an `is` function that takes an enum
Return value determines type of `TurnEvent` as defined by `EventMap`

```ts
public is<T extends TurnEventType, K = EventMap[T]>(event_type: T): this is K {
    return event_type === this.event_type
}
```

The result is this: Calling `turn_event.is(TurnEventType.ADD)` will type guard `turn_event` into `AddTurnEvent`. This means that `turn_event` will be considered to be of the type `AddTurnEvent` inside of the if-block.

```ts
if (turn_event.is(TurnEventType.ADD)) {
    console.log("Add-event! Adding to", turn_event.area_to_add_to)
}
```

Granted, this can also be done with the `instanceof` operator. However, this example demonstrates a few neat TypeScript features. I should also say that these type "guards" are simply sprinkles on top of JavaScript. The `is`-function is a simple integer comparison, and property access is just normal spray and pray behaviour.

I probably won't be merging this one, and just go with using `instanceof` instead